### PR TITLE
Cancel advancing to next card in prop change

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -200,7 +200,6 @@ export default class SwipeCards extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.cards !== this.props.cards) {
-      console.log('setting cards', this.props.cards, nextProps.cards);
 
       this.setState({
         cards: [].concat(nextProps.cards),


### PR DESCRIPTION
If props were changing there was a bug where a _goToNextCard could be scheduled, the props updated then the _goToNextCard called on the newly updated props. 

This cancels any card animations on new props (because the component is about to re-render itself anyway) and checks if the animation was cancelled before calling _goToNextCard.