### PR TITLE
Check gesture state instead of native event

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -117,12 +117,12 @@ export default class SwipeCards extends Component {
 
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponderCapture: (e, gestureState) => {
-        this.lastX = e.nativeEvent.locationX;
-        this.lastY = e.nativeEvent.locationY;
+        this.lastX = gestureState.moveX;
+        this.lastY = gestureState.moveY;
         return false;
       },
       onMoveShouldSetPanResponderCapture: (e, gestureState) => {
-        return (Math.abs(this.lastX - e.nativeEvent.locationX) > 5 || Math.abs(this.lastY - e.nativeEvent.locationY) > 5);
+        return (Math.abs(this.lastX - gestureState.moveX) > 5 || Math.abs(this.lastY - gestureState.moveY) > 5);
       },
 
       onPanResponderGrant: (e, gestureState) => {


### PR DESCRIPTION
Native event locations are not being updated in Android, however the gesture state locations are being updated. Difference calculations should use gesture state otherwise no difference will ever be seen.